### PR TITLE
Remove non-ascii characters from setup config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ setup(
     ],
     install_requires=['setuptools'],
     zip_safe=True,
-    author='Víctor Mayoral Vilches',
+    author='Victor Mayoral Vilches',
     author_email='vmayoral@acutronicrobotics.com',
-    maintainer='Víctor Mayoral Vilches',
+    maintainer='Victor Mayoral Vilches',
     maintainer_email='vmayoral@acutronicrobotics.com',
     keywords=['ROS2'],
     classifiers=[


### PR DESCRIPTION
Using non-ascii in the setup file requires the building system to handle UTF language options (e.g. we have to take this into account in our Docker images too).

Simply removing this characters solves this issue. I'm using Qt-Creator and did not find any other workaround.  https://gist.github.com/nzlz/fbcca29a572ea2a3f5ce762a612fb65e